### PR TITLE
feature/enable-folder-uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,50 @@ The code always uses the Images get_serving_url for images (gif/png/jpg).
 This image serving url allows dynamic resizing and cropping.  
 The use_blobstore option configures the serving_url type for non-images.  
 The use_blobstore default (= True) can be overwritten in appengine_config.py
-
-blob_upload contains the code to upload a file to cloudstorage:
+---
+blob_upload contains the code to upload files to cloudstorage:
 
     upload: https://<appid>.appspot.com/blob_upload
     or: http://localhost:8080/blob_upload
+    
+The directory structure will be maintained when uploading a folder. 
 
+E.g.
+
+```
+-bucket_dir
+    -subfolder_01
+        - image_01.jpg
+        - image_02.jpg
+```
+Uplading the `subfolder_01` directory will create two entries with the paths:
+
+```
+/bucket_dir/subfolder_01/image_01.jpg
+/bucket_dir/subfolder_01/image_02.jpg
+```
+
+---
 To serve the data, you can use in your Jinja HTML template:
 
     js:  <script type="text/javascript" src="{{ serving_url }}"></script>
     css: <link type="text/css" rel="stylesheet" href="{{ serving_url }}">
     pdf: <a href="{{ serving_url }}" target="_blank">Test PDF</a>
     img: <img  alt="{{ filename }}" src="{{ serving_url }}" />
-
+---
 In GAE production the serving url looks like:
 
     images: https://lhN.ggpht.com/NlCARAtN.........3NQW9ZxYpms=s698
     other:  https://storage.googleapis.com/default_bucket/file_name
     or a blobstore like url, when use_blobstore = True
-    
+
 And in the SDK:
 
     images: http://localhost:8080/_ah/img/encoded_gs_file:YXBwX2R......Y3Nz
     other:  https://localhost:8080/_ah/gcs/default_bucket/file_name
     or a blobstore like url, when use_blobstore = True
     Note: The SDK encoded_gs_file id = base64.urlsafe_b64encode(app_default_bucket/filename)
-
+---
 The benefits of use_blobstore = False (GCS host):
 
     - Cheaper and probably significantly faster. 

--- a/app.yaml
+++ b/app.yaml
@@ -3,6 +3,7 @@ version: 3
 runtime: python27
 api_version: 1
 threadsafe: yes
+service: blobstore
 
 handlers:
 

--- a/blob_files.py
+++ b/blob_files.py
@@ -43,14 +43,8 @@ class BlobFiles(ndb.Model):
             BlobFiles entity, if the new gcs_filename is not equal to the existing gcs path
             use_blobstore controls the type of serving_url. True: use Blobkey; False: use gcs_filename
         """
-
         gcs_filename = '/%s%s/%s' % (bucket or app_identity.get_default_gcs_bucket_name(), folder, filename)
-        bf = cls.get_by_id(filename)
-        if bf and gcs_filename != bf.gcs_filename:
-            logging.error('new gcs_filename: %s already exists as gcs_filename: %s' % (gcs_filename,  bf.gcs_filename))
-            return None
-
-        return BlobFiles(id=filename, filename=filename, folder=folder, gcs_filename=gcs_filename)
+        return BlobFiles(id=gcs_filename, filename=filename, folder=folder, gcs_filename=gcs_filename)
 
     def properties(self):
 
@@ -140,6 +134,8 @@ def blob_archive(new_bf=None):
         """
 
         for bf in BlobFiles.query().filter(BlobFiles.key != archive_key).map(callback, keys_only=True):
+            if not bf:
+                continue
             if insert and new_bf.key == bf.key:
                 insert = False  # no index inconsistency
             yield bf

--- a/templates/blob_links.html
+++ b/templates/blob_links.html
@@ -5,8 +5,9 @@
 {% else %}
 <p><b>Serving url</b> (download) :</p>
 <ul class="no-markers">
-    <li>Zip archive : <a href="{{ bzf_url }}">{{ bzf_name }}</a></li>
-    <li>File upload : <a href="{{ bf_url }}">{{ bf_name }}</a></li>
+    {% for bf_url, bf_name in files %}
+        <li>File upload : <a href="{{ bf_url }}">{{ bf_name }}</a></li>
+    {% endfor %}
 </ul>
 {% endif %}
 {%- endblock -%}

--- a/templates/blob_upload.html
+++ b/templates/blob_upload.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -17,7 +17,7 @@
         <li><label><input type="radio" name="use_blobstore"
                           {% if use_blobstore %}checked="checked" {% endif %}value="T">Blobkey (served by your BlobstoreDownloadHandler)</label></li>
     </ul>
-    <div><input type="file" name="file"/></div>
+    <div><input type="file" name="file" webkitdirectory multiple /></div>
     <div><br><input type="submit" value="Upload" formaction="/blob_upload" formmethod="post"></div>
 </form>
 {%- block links -%}


### PR DESCRIPTION
1. Updates template to print all files uploaded.
2. Updates template to support the upload of folders.
3. Adds service definition in `app.yaml` to allow for running with
additional App Engine services without clashing with the default
service.
4. Removes error when uploading a file that already exists. Instead now
the service will replace said file.
5. Changes the key off the Datastore entity to include the folder
structure such that files with the same name but different paths may be
uploaded.
6. Adds support for adding multiple blobs at once.
7. Adds redirect to `/blob_upload` from root (`/`).
8. Disables archive functionality as it drastically increases
efficiency.